### PR TITLE
Display product type categories with up to 3 products under each

### DIFF
--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -22,7 +22,23 @@ namespace Bangazon.Controllers
         // GET: ProductTypes
         public async Task<IActionResult> Index()
         {
-            return View(await _context.ProductType.ToListAsync());
+            // Build list of Product instances for display in view
+            // LINQ is awesome
+           
+            var productsByType = await (
+                from t in _context.ProductType
+                join p in _context.Product
+                on t.ProductTypeId equals p.ProductTypeId
+                group new { t, p } by new { t.ProductTypeId, t.Label } into grouped
+                select new GroupedProducts
+                {
+                    TypeId = grouped.Key.ProductTypeId,
+                    TypeName = grouped.Key.Label,
+                    ProductCount = grouped.Select(x => x.p.ProductId).Count(),
+                    Products = grouped.Select(x => x.p).Take(3)
+                }).ToListAsync();
+
+            return View(productsByType);
         }
 
         // GET: ProductTypes/Details/5

--- a/Bangazon/Views/ProductTypes/Index.cshtml
+++ b/Bangazon/Views/ProductTypes/Index.cshtml
@@ -1,35 +1,23 @@
-﻿@model IEnumerable<Bangazon.Models.ProductType>
+﻿@model List<Bangazon.Models.GroupedProducts>
 
 @{
     ViewData["Title"] = "Index";
 }
 
-<h1>Index</h1>
+<h1>Product Categories</h1>
 
 <p>
     <a asp-action="Create">Create New</a>
 </p>
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-                @Html.DisplayNameFor(model => model.Label)
-            </th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-@foreach (var item in Model) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Label)
-            </td>
-            <td>
-                <a asp-action="Edit" asp-route-id="@item.ProductTypeId">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.ProductTypeId">Details</a> |
-                <a asp-action="Delete" asp-route-id="@item.ProductTypeId">Delete</a>
-            </td>
-        </tr>
+
+@foreach (var item in Model)
+{
+    <h3>
+        <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Details" asp-route-id="@item.TypeId">@item.TypeName (@item.ProductCount):</a>
+    </h3>
+
+    @foreach (var product in item.Products)
+    {
+        <a class="nav-link" asp-area="" asp-controller="Products" asp-action="Details" asp-route-id="@product.ProductId">@product.Title</a>
+    }
 }
-    </tbody>
-</table>

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -33,7 +33,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Products" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Product Types</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Index">Product Types</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Sell Something</a>


### PR DESCRIPTION
Fixes:
-Product types are now listed with up to three products under each category. 
- All product types have the total number of products listed next to them in parenthesis. 
- All product and product type names are links to that item's details page. 

Changes proposed in this request & reasons behind organizational or architectural decisions:
-N/A

Steps to test:
- Click on Product Types from the nav bar

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):
-N/A

Commit message:
- product types index view shows all product types w/ up to 3 products. All product and product type names are links to the details page of the item

Link to feature ticket:
- https://github.com/nss-day-cohort-30/bangazon-site-mighty-mahi-mahi/issues/3

@mighty-mahi-mahi
