### PR TITLE
Products display when product type is selected 

### DIFF
--- a/Bangazon/Bangazon.csproj
+++ b/Bangazon/Bangazon.csproj
@@ -6,10 +6,6 @@
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Remove="Views\ProductTypes\AllProductsByType.cshtml" />
-  </ItemGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />

--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -41,24 +41,7 @@ namespace Bangazon.Controllers
 
             return View(productsByType);
         }
-        // GET: AllProductsByType
-         public async Task<IActionResult> AllProductsByType(int? id)
-        {
-            var allProductsByType = await (
-                from t in _context.ProductType
-                join p in _context.Product
-                on t.ProductTypeId equals p.ProductTypeId
-                group new { t, p } by new { t.ProductTypeId, t.Label } into groupes
-                select new GroupedProducts
-                {
-                    TypeId = groupes.Key.ProductTypeId,
-                    TypeName = groupes.Key.Label,
-                    Products = groupes.Select(x => x.p)
-                }).ToListAsync();
-
-            return View(allProductsByType);
-        } 
-
+        
         // GET: ProductTypes/Details/5
         public async Task<IActionResult> Details(int? id)
         {
@@ -68,6 +51,7 @@ namespace Bangazon.Controllers
             }
 
             var productType = await _context.ProductType
+                .Include(pt => pt.Products)
                 .FirstOrDefaultAsync(m => m.ProductTypeId == id);
             if (productType == null)
             {

--- a/Bangazon/Views/Products/Index.cshtml
+++ b/Bangazon/Views/Products/Index.cshtml
@@ -53,7 +53,7 @@
                 @Html.DisplayFor(modelItem => item.Quantity)
             </td>
             <td>
-                <a asp-controller="ProductTypes" asp-action="AllProductsByType" asp-route-id="@item.ProductTypeId" >@Html.DisplayFor(modelItem => item.ProductType.Label)</a>
+                <a asp-controller="ProductTypes" asp-action="Details" asp-route-id="@item.ProductTypeId" >@Html.DisplayFor(modelItem => item.ProductType.Label)</a>
             </td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.ProductId">Edit</a> |


### PR DESCRIPTION
Fixes:
-Selecting the product type should bring up a list of all associated products

Steps to test:
-Open the program
-select any product type

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):
-
-

Commit message:
-

Link to feature ticket:
-

@mighty-mahi-mahi
