### PR TITLE
Delete payment type bn

### DIFF
--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -111,6 +111,7 @@ namespace Bangazon.Controllers
                 return NotFound();
             }
 
+            ModelState.Remove("User");
             if (ModelState.IsValid)
             {
                 try
@@ -129,7 +130,7 @@ namespace Bangazon.Controllers
                         throw;
                     }
                 }
-                return RedirectToAction(nameof(Index));
+                return RedirectToAction("Profile", "Home");
             }
             ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id", paymentType.UserId);
             return View(paymentType);
@@ -162,7 +163,7 @@ namespace Bangazon.Controllers
             var paymentType = await _context.PaymentType.FindAsync(id);
             _context.PaymentType.Remove(paymentType);
             await _context.SaveChangesAsync();
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction("Profile", "Home");
         }
 
         private bool PaymentTypeExists(int id)

--- a/Bangazon/Models/PaymentType.cs
+++ b/Bangazon/Models/PaymentType.cs
@@ -22,6 +22,7 @@ namespace Bangazon.Models
 
     [Required]
     [StringLength(20)]
+    [Display(Name ="Account Number")]
     public string AccountNumber { get; set; }
 
     [Required]

--- a/Bangazon/Views/Home/Profile.cshtml
+++ b/Bangazon/Views/Home/Profile.cshtml
@@ -29,7 +29,8 @@
             </dd>
         </dl>
         <div>
-            <a asp-controller="PaymentTypes" asp-action="Edit" asp-route-id="@type.PaymentTypeId">Edit</a>
+            <a asp-controller="PaymentTypes" asp-action="Edit" asp-route-id="@type.PaymentTypeId">Edit</a> | 
+            <a asp-controller="PaymentTypes" asp-action="Delete" asp-route-id="@type.PaymentTypeId">Delete</a>
         </div>
         <hr />
     }

--- a/Bangazon/Views/Home/Profile.cshtml
+++ b/Bangazon/Views/Home/Profile.cshtml
@@ -29,9 +29,9 @@
             </dd>
         </dl>
         <div>
-            <a asp-controller="PaymentTypes" asp-action="Edit" asp-route-id="@type.PaymentTypeId">Edit</a> |
-            <a asp-action="Index">Back to List</a>
+            <a asp-controller="PaymentTypes" asp-action="Edit" asp-route-id="@type.PaymentTypeId">Edit</a>
         </div>
         <hr />
     }
+    <a asp-controller="Products" asp-action="Index">Back to Home Screen</a>
 </div>

--- a/Bangazon/Views/PaymentTypes/Delete.cshtml
+++ b/Bangazon/Views/PaymentTypes/Delete.cshtml
@@ -12,12 +12,6 @@
     <hr />
     <dl class="row">
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.DateCreated)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.DateCreated)
-        </dd>
-        <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Description)
         </dt>
         <dd class = "col-sm-10">
@@ -29,17 +23,11 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.AccountNumber)
         </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.User)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.User.Id)
-        </dd class>
     </dl>
     
     <form asp-action="Delete">
         <input type="hidden" asp-for="PaymentTypeId" />
         <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-action="Index">Back to List</a>
+        <a asp-controller="Home" asp-action="Profile">Back to Profile</a>
     </form>
 </div>

--- a/Bangazon/Views/PaymentTypes/Edit.cshtml
+++ b/Bangazon/Views/PaymentTypes/Edit.cshtml
@@ -13,6 +13,8 @@
         <form asp-action="Edit">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="PaymentTypeId" />
+            <input type="hidden" asp-for="UserId" />
+            <input type="hidden" asp-for="DateCreated" />
             <div class="form-group">
                 <label asp-for="Description" class="control-label"></label>
                 <input asp-for="Description" class="form-control" />
@@ -22,11 +24,6 @@
                 <label asp-for="AccountNumber" class="control-label"></label>
                 <input asp-for="AccountNumber" class="form-control" />
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="UserId" class="control-label"></label>
-                <select asp-for="UserId" class="form-control" asp-items="ViewBag.UserId"></select>
-                <span asp-validation-for="UserId" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-primary" />

--- a/Bangazon/Views/ProductTypes/Details.cshtml
+++ b/Bangazon/Views/ProductTypes/Details.cshtml
@@ -10,21 +10,20 @@
     <h4>@Model.Label</h4>
     <hr />
     <dl class="row">
-        
-            @foreach (var item in Model.Products)
 
-            {
-        
+        @foreach (var item in Model.Products)
+
+        {
             <dt class="col-sm-2">
                 <a asp-action="Details" asp-controller="Products" asp-route-id="@item.ProductId"> @Html.DisplayFor(model => item.Title) </a>
-</dt>
-       
-                <dd class=" col-sm-10">
-                    @Html.DisplayTextFor(model => item.Description)
-                </dd>
-            }
-            
-</dl>
+            </dt>
+
+            <dd class=" col-sm-10">
+                @Html.DisplayTextFor(model => item.Description)
+            </dd>
+        }
+
+    </dl>
 </div>
 <div>
     <a asp-action="Edit" asp-route-id="@Model.ProductTypeId">Edit</a> |


### PR DESCRIPTION
Fixes:
- added User Profile link in navbar so User can access their payment types
- can now edit and delete payment types

Changes proposed in this request & reasons behind organizational or architectural decisions:
- 
-

Steps to test:
- select 'Profile' from the nav bar
- add a payment type
- edit that payment type
- delete that payment type

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):
-
-

Commit message:
- "added User Profile view and link in navbar"
- "can now edit and delete payment types"

Link to feature ticket:
- https://github.com/nss-day-cohort-30/bangazon-site-mighty-mahi-mahi/issues/7

@mighty-mahi-mahi
