### PR TITLE
Incomplete Order Report

### DIFF
--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -200,6 +200,21 @@ namespace Bangazon.Controllers
             return View(abandonedProductTypes);
         }
 
+        //GET: Orders/IncompleteOrders
+        public async Task<IActionResult> IncompleteOrders()
+        {
+            // get a list of users with orders
+            var usersOpenOrders = _context.ApplicationUsers
+                .Include(au => au.Orders)
+                .ThenInclude(o => o.OrderProducts)
+                .ThenInclude(op => op.Product)
+                .OrderBy(au => au.LastName)
+                .ToList()
+                ;
+
+            return View(usersOpenOrders);
+        }
+
 
 
 

--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -158,7 +158,14 @@ namespace Bangazon.Controllers
                 ;
 
             // gets only users who have 1 or more open ordersgi
-            var usersWithMultipleNullOrders = usersWithNullOrders.Where(u => u.Orders.Count() >= 2).ToList();
+            var usersWithMultipleNullOrders = usersWithNullOrders
+                .Where(u => u.Orders
+                    .Where(o => o.DateCompleted == null)
+                    .Count() >= 2)
+                .ToList()
+                .OrderByDescending(u => u.Orders.Where(o => o.DateCompleted == null).Count())
+                .ToList()
+                ;
 
             return View(usersWithMultipleNullOrders);
         }

--- a/Bangazon/Views/Orders/IncompleteOrders.cshtml
+++ b/Bangazon/Views/Orders/IncompleteOrders.cshtml
@@ -1,0 +1,30 @@
+﻿@model List<Bangazon.Models.ApplicationUser>
+@{
+    ViewData["Title"] = "IncompleteOrders";
+}
+
+<h1>IncompleteOrders:</h1>
+
+@foreach (var user in Model)
+{
+    //check to see if user has open order/orders
+    @if (user.Orders.Where(o => o.DateCompleted == null).Count() >= 1)
+    {
+        <h3>@user.FirstName @user.LastName</h3>
+
+        @foreach (var order in user.Orders)
+        {
+            @if (order.DateCompleted == null)
+            {
+                <h4>Order # @order.OrderId</h4>
+                <ol>
+                    @foreach (var product in order.OrderProducts)
+                    {
+                        <li>@product.Product.Title</li>
+                    }
+                </ol>
+            }
+        }
+    }
+}
+

--- a/Bangazon/Views/Orders/Reports.cshtml
+++ b/Bangazon/Views/Orders/Reports.cshtml
@@ -12,5 +12,8 @@
     <li>
         <a class="nav-link" asp-area="" asp-controller="Orders" asp-action="AbandonedProducts">Abandoned Product Types</a>
     </li>
+    <li>
+        <a class="nav-link" asp-area="" asp-controller="Orders" asp-action="IncompleteOrders">Incomplete Orders</a>
+    </li>
 </ul>
 

--- a/Bangazon/Views/Products/Index.cshtml
+++ b/Bangazon/Views/Products/Index.cshtml
@@ -62,9 +62,9 @@
                 <a asp-controller="ProductTypes" asp-action="Details" asp-route-id="@item.ProductTypeId">@Html.DisplayFor(modelItem => item.ProductType.Label)</a>
             </td>
             <td>
-                <a asp-action="Edit" asp-route-id="@item.ProductId">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.ProductId">Details</a> |
-                <a asp-action="Delete" asp-route-id="@item.ProductId">Delete</a>
+                @*<a asp-action="Edit" asp-route-id="@item.ProductId">Edit</a> |*@
+                <a asp-action="Details" asp-route-id="@item.ProductId">Details</a>
+                @*<a asp-action="Delete" asp-route-id="@item.ProductId">Delete</a>*@
             </td>
         </tr>
 }


### PR DESCRIPTION
Fixes:
- Fixed home page to only show details link next to products
- Created Incomplete Orders report in reports section

Changes proposed in this request & reasons behind organizational or architectural decisions:
-N/A

Steps to test:
- Start Bangazon
- Ensure you have an open order with items in the cart
- Click reports
- Click incomplete orders report

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):
-N/A

Commit message:
- incomplete orders report shows User/OrderNum/Products in order
--

Link to feature ticket:
-https://github.com/nss-day-cohort-30/bangazon-site-mighty-mahi-mahi/issues/12

@mighty-mahi-mahi
