### PR TITLE
My Account Order History Report With Details Pages

### DIFF
--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -83,8 +83,8 @@ namespace Bangazon.Controllers
                                .Where(pt => pt.UserId == user.Id)
                                .Select(li => new SelectListItem
                                {
-                                    Text = li.Description,
-                                    Value = li.PaymentTypeId.ToString()
+                                   Text = li.Description,
+                                   Value = li.PaymentTypeId.ToString()
                                }).ToList();
             paymentTypes.Insert(0, new SelectListItem
             {
@@ -113,7 +113,7 @@ namespace Bangazon.Controllers
             //Take each product, createa a new OrderLineItem object and place in placeholder array shoppingCartLineItems
             productsInCart.ForEach(p =>
             {
-                Product product =  _context.Product.SingleOrDefault(cp => cp.ProductId == p.key);
+                Product product = _context.Product.SingleOrDefault(cp => cp.ProductId == p.key);
 
                 OrderLineItem newLineItem = new OrderLineItem
                 {
@@ -213,6 +213,27 @@ namespace Bangazon.Controllers
                 ;
 
             return View(usersOpenOrders);
+        }
+
+        //GET: Orders/OrderHistory: 
+        [Authorize]
+        public async Task<IActionResult> OrderHistory()
+        {
+            // Get the current user
+            var user = await GetCurrentUserAsync();
+
+            // Get List of Completed Orders
+            var usersPastOrders = _context.Order
+                .Include(o => o.User)
+                .Where(o => o.User == user)
+                .Where(o => o.DateCompleted != null)
+                .Include(o => o.OrderProducts)
+                .ThenInclude(op => op.Product)
+                .OrderByDescending(o => o.DateCompleted)
+                .ToList()
+                ;
+
+            return View(usersPastOrders);
         }
 
 
@@ -369,7 +390,7 @@ namespace Bangazon.Controllers
             }
             //ViewData["PaymentTypeId"] = new SelectList(_context.PaymentType, "PaymentTypeId", "AccountNumber", order.PaymentTypeId);
             //ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id", order.UserId);
-            return  RedirectToAction(nameof(ShoppingCart));
+            return RedirectToAction(nameof(ShoppingCart));
         }
 
         // POST: Orders/DeleteProduct
@@ -384,11 +405,11 @@ namespace Bangazon.Controllers
             // Find the product requested
             List<OrderProduct> productToDelete = await _context.OrderProduct
                 .Where(op => op.OrderId == openOrder.OrderId && op.ProductId == id).ToListAsync();
-                
-                
-            foreach(var product in productToDelete)
+
+
+            foreach (var product in productToDelete)
             {
-            _context.Remove(product);
+                _context.Remove(product);
             }
             await _context.SaveChangesAsync();
 

--- a/Bangazon/Views/Home/Profile.cshtml
+++ b/Bangazon/Views/Home/Profile.cshtml
@@ -7,8 +7,12 @@
 <h1>Profile</h1>
 
 <div>
+    <h4>
+        <a asp-controller="Orders" asp-action="OrderHistory">View Order History</a>
+    </h4>
+
     <div>
-        <h4>Payment Methods</h4>
+        <h4>Payment Methods:</h4>
         <a asp-controller="PaymentTypes" asp-action="Create">Add New Payment Method</a>
     </div>
     <hr />

--- a/Bangazon/Views/Orders/Details.cshtml
+++ b/Bangazon/Views/Orders/Details.cshtml
@@ -1,42 +1,58 @@
-﻿@model Bangazon.Models.Order
+﻿@model Bangazon.Models.OrderViewModels.OrderDetailViewModel
 
 @{
     ViewData["Title"] = "Details";
 }
 
-<h1>Details</h1>
+@{
+    double orderTotal = new int();
+    orderTotal = Model.LineItems.Sum(li => li.Total);
+}
+
+<h1>Order Details</h1>
+<br />
+<br />
 
 <div>
-    <h4>Order</h4>
-    <hr />
-    <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.DateCreated)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.DateCreated)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.DateCompleted)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.DateCompleted)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.User)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.User.Id)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.PaymentType)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.PaymentType.AccountNumber)
-        </dd>
-    </dl>
+    <h2>
+        Order #@Model.Order.OrderId
+    </h2>
+    <br />
+    <h5>
+        Total: $@orderTotal
+    </h5>
+    <br />
 </div>
-<div>
-    @*<a asp-action="Edit" asp-route-id="@Model.OrderId">Edit</a> |*@
-    <a asp-action="Index">Back to List</a>
-</div>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                Title
+            </th>
+            <th>
+                # in Order
+            </th>
+            <th>
+                Total Price
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Model.LineItems)
+        {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Product.Title)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Units)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Total)
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/Bangazon/Views/Orders/OrderHistory.cshtml
+++ b/Bangazon/Views/Orders/OrderHistory.cshtml
@@ -1,0 +1,39 @@
+﻿@model List<Bangazon.Models.Order>
+@{
+    ViewData["Title"] = "OrderHistory";
+}
+
+<h1>@Model[0].User.FirstName's Order History</h1>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                Order #
+            </th>
+            <th>
+                Date Completed
+            </th>
+            <th>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var order in Model)
+        {
+            <tr>
+                <td>
+                    @order.OrderId
+                </td>
+                <td>
+                    @order.DateCompleted
+                </td>
+                <td>
+                    <a asp-controller="Orders" asp-action="Details" asp-route-id="@order.OrderId">Details</a>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -48,7 +48,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Profile">Profile</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Profile">My Account</a>
                         <li>
                             <form asp-controller="Products" asp-action="Index">
                                 <p>


### PR DESCRIPTION
Fixes:
- My Account on the nav bar now allows users to see their completed orders
- Orders listed in order history now show an order details page when clicked on

Changes proposed in this request & reasons behind organizational or architectural decisions:
-Changed "profile" section on nav bar to be named "My Account"

Steps to test:
-Start Bangazon
- Ensure logged in user has multiple completed orders and an open order
- Click on My Account
- Click on View Order History
- Check to make sure that the open order is not present
- Click on the details page for a specific order
- Check to make sure that the OrderId, Order Total, and all order line items are displayed

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):
-N/A

Commit message:
- logged in user's order history now shows the details for all completed orders
--

Link to feature ticket:
-https://github.com/nss-day-cohort-30/bangazon-site-mighty-mahi-mahi/issues/18

@mighty-mahi-mahi
