### PR TITLE
users cannot add products with prices that exceed 10,000

### DIFF
--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -24,6 +24,7 @@ namespace Bangazon.Models
     public string Title { get; set; }
 
     [Required]
+    [Range(0, 9999.99)]
     [DisplayFormat(DataFormatString = "{0:C}")]
     [Display(Name = "Price Per")]
     public double Price { get; set; }

--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -24,7 +24,7 @@ namespace Bangazon.Models
     public string Title { get; set; }
 
     [Required]
-    [Range(0, 9999.99)]
+    [Range(0, 10000)]
     [DisplayFormat(DataFormatString = "{0:C}")]
     [Display(Name = "Price Per")]
     public double Price { get; set; }


### PR DESCRIPTION
Fixes:
- Users cannot add a price that exceeds $10,000

Changes proposed in this request & reasons behind organizational or architectural decisions:
-N/A

Steps to test:
-Start Bangazon
- Attempt to list a new product for more than $10,000

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):
-N/A

Commit message:
- users cannot add products with prices that exceed 10,000
--

Link to feature ticket:
-https://github.com/nss-day-cohort-30/bangazon-site-mighty-mahi-mahi/issues/20

@mighty-mahi-mahi
