### PR TITLE
#19 Ticket images included in search 

### DIFF
--- a/Bangazon/Bangazon.csproj
+++ b/Bangazon/Bangazon.csproj
@@ -22,7 +22,7 @@
 
 
   <ItemGroup>
-    <Folder Include="wwwroot\images\" />
+    <Folder Include="wwwroot\images\thumb\" />
   </ItemGroup>
 
 </Project>

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -31,16 +31,19 @@ namespace Bangazon.Controllers
         // GET: Products
         public async Task<IActionResult> Index(string SearchString)
         {
+            ViewBag.SearchString = false;
             // if user has entered search term into search bar, list of products containing the search string will be returned
             if (SearchString != null)
             {
-                var applicationDbContext1 = _context.Product.Include(p => p.ProductType)
+                
+                var applicationDbContext = _context.Product.Include(p => p.ProductType)
                    .Include(p => p.User)
 
                    .Where(p => p.Title.Contains(SearchString) || p.City.Contains(SearchString))
 
                    .OrderByDescending(p => p.DateCreated);
-                return View(await applicationDbContext1.ToListAsync());
+                ViewBag.SearchString = true;
+                return View(await applicationDbContext.ToListAsync());
             }
             // if the search bar is blank the complete list of products will be returned to the user
             else

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -42,8 +42,8 @@ namespace Bangazon.Controllers
                    .Where(p => p.Title.Contains(SearchString) || p.City.Contains(SearchString))
 
                    .OrderByDescending(p => p.DateCreated);
-                ViewBag.SearchString = true;
-                return View(await applicationDbContext.ToListAsync());
+                    ViewBag.SearchString = true;
+                    return View(await applicationDbContext.ToListAsync());
             }
             // if the search bar is blank the complete list of products will be returned to the user
             else

--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -40,7 +40,7 @@
         </dt>
         <dd>
 
-        <img src="/images/@Model.ImagePath"/>
+        <img src="/images/@Model.ImagePath" class="imageDisplay"/>
 
         </dd>
     </dl>

--- a/Bangazon/Views/Products/Index.cshtml
+++ b/Bangazon/Views/Products/Index.cshtml
@@ -4,7 +4,13 @@
     ViewData["Title"] = "Index";
 }
 
-<h1>Index</h1>
+@if (ViewBag.SearchString == true)
+{
+    <h1>Search Results</h1>
+}
+else {
+    <h1>Index</h1>
+}
 
 
 <p>
@@ -32,6 +38,9 @@
                 @Html.DisplayNameFor(model => model.City)
             </th>
             <th>
+                @Html.DisplayNameFor(model => model.ImagePath)
+            </th>
+            <th>
                 @Html.DisplayNameFor(model => model.ProductType)
             </th>
             <th></th>
@@ -57,6 +66,12 @@
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.City)
+            </td>
+            <td>
+                @if (ViewBag.SearchString = true)
+                {
+                    <img src="~/images/@item.ImagePath" id="imageDisplay" />
+                }
             </td>
             <td>
                 <a asp-controller="ProductTypes" asp-action="Details" asp-route-id="@item.ProductTypeId">@Html.DisplayFor(modelItem => item.ProductType.Label)</a>

--- a/Bangazon/wwwroot/css/site.css
+++ b/Bangazon/wwwroot/css/site.css
@@ -7,15 +7,28 @@ a.navbar-brand {
   word-break: break-all;
 }
 
+
+
+
 /* Sticky footer styles
 -------------------------------------------------- */
 html {
-  font-size: 14px;
+    font-size: 14px;
 }
 @media (min-width: 768px) {
   html {
     font-size: 16px;
   }
+}
+
+#imageDisplay {
+    height: 75px;
+    width: 75px;
+}
+
+img.imageDisplay {
+    height:75px;
+    width: 75px;
 }
 
 .border-top {


### PR DESCRIPTION
Fixes:
- when users search a product the images will show up
- images have also been resized to 75x75px
- 

Changes proposed in this request & reasons behind organizational or architectural decisions:
-
-

Steps to test:
-if user searches text at top of page should read "Search results" otherwise it will read "Index"
-
-
-

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):
-
-

Commit message:
- images will display in search results. text at top of page changes depending on if the user has searched

Link to feature ticket:
- #19 

@mighty-mahi-mahi
